### PR TITLE
contributor management

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,0 +1,19 @@
+clementcanonne:
+  name: Clément Canonne
+  homepage: http://www.cs.columbia.edu/~ccanonne/
+  
+gautamkamath:
+  name: Gautam Kamath
+  homepage: http://www.gautamkamath.com/
+
+thomassteinke:
+  name: Thomas Steinke
+  homepage: http://www.thomas-steinke.net/
+
+jonullman:
+  name: Jonathan Ullman
+  homepage: https://www.ccs.neu.edu/home/jullman/
+  
+stevenwu:
+  name: Zhiwei Steven Wu
+  homepage: https://zstevenwu.com/

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,9 +10,8 @@ layout: default
   </div>
 
   <div class="date">
-      Posted {% if page.author %}by {% if page.authorurl %}<a href="{{ page.authorurl }}">{% endif %}{{ page.author }}{% if page.authorurl %}</a>{% endif %} {% endif %}on {{ page.date | date: "%B %e, %Y" }}. </br>
+      Posted {% if page.authors %}by{% for author in page.authors %}{% if forloop.first == false %}{% if forloop.last == true %} and{% else %},{% endif %}{% endif %} <a href="{{ site.data.contributors[author].homepage }}">{{ site.data.contributors[author].name }}</a>{% endfor %}{% endif %} on {{ page.date | date: "%B %e, %Y" }}.
   </div>
-  
   <div class="post-categories">
     {% if post %}
       {% assign categories = post.categories %}

--- a/_posts/2020-7-11-Welcome.md
+++ b/_posts/2020-7-11-Welcome.md
@@ -2,14 +2,16 @@
 layout: post
 title: Welcome to differentialprivacy.org
 comments: true
-author: Thomas Steinke
-authorurl: http://www.thomas-steinke.net/
+authors: 
+    - clementcanonne
+    - gautamkamath
+    - thomassteinke 
+    - jonullman
+    - stevenwu
 categories: Updates
 ---
 
-Hello, welcome to this new website. As you can see, we haven't got much content yet. But it will come. :-)
-
-We anticipate posting a variety of content, from announcements to mini-surveys of topics in the differential privacy research literature. 
+Hello, welcome to this new website for the differential privacy research community. We anticipate posting a variety of content, from announcements to mini-surveys of topics in the differential privacy research literature. 
 
 Please suggest posts (in the comments below or by contacting the organizers directly). We do hope that members of the community will contribute to this website.
 

--- a/_posts/2020-7-11-Welcome.md
+++ b/_posts/2020-7-11-Welcome.md
@@ -3,7 +3,6 @@ layout: post
 title: Welcome to differentialprivacy.org
 comments: true
 authors: 
-    - clementcanonne
     - gautamkamath
     - thomassteinke 
     - jonullman
@@ -11,10 +10,15 @@ authors:
 categories: Updates
 ---
 
-Hello, welcome to this new website for the differential privacy research community. We anticipate posting a variety of content, from announcements to mini-surveys of topics in the differential privacy research literature. 
+Hello, welcome to this new website. Our goal is to serve as a hub for the differential privacy research community and to promote the work in this area.
 
-Please suggest posts (in the comments below or by contacting the organizers directly). We do hope that members of the community will contribute to this website.
+We anticipate posting a variety of content, from announcements to mini-surveys of topics in the differential privacy literature. 
+
+This is a community-driven effort and we welcome participation. 
+If you are interested in contributing, please reach out to us (by email or in the comments below ). 
 
 To get things started, here is a definition:
 
+> **Definition 1.** [_\[DMNS06\]_](https://journalprivacyconfidentiality.org/index.php/jpc/article/view/405)
+> 
 > A randomized algorithm \\(M : \mathcal{X}^n \to \mathcal{Y}\\) is \\((\varepsilon,\delta)\\)-differentially private if, for all \\(x,x' \in \mathcal{X}^n\\) differing on a single entry and all measurable \\(E \subseteq \mathcal{Y}\\), we have \\[\mathbb{P}[M(x) \in E] \le e^\varepsilon \cdot \mathbb{P}[M(x') \in E]  + \delta.\\]

--- a/about.md
+++ b/about.md
@@ -6,23 +6,15 @@ permalink: /about/
 
 This website is intended to serve as a resource for the differential privacy research community, as well as for those seeking to learn more about the subject. If you have any comments or suggestions for topics to cover, please contact the site administrators.
 
-## Team
-#### Admins
-* [Gautam Kamath](http://www.gautamkamath.com/)
-* [Thomas Steinke](http://www.thomas-steinke.net/)
-* [Jonathan Ullman](https://www.ccs.neu.edu/home/jullman/)
-* [Zhiwei Steven Wu](https://zstevenwu.com/)
-
-#### Contributors
-* [Clément Canonne](http://www.cs.columbia.edu/~ccanonne/)
-* [Gautam Kamath](http://www.gautamkamath.com/)
-* [Thomas Steinke](http://www.thomas-steinke.net/)
-* [Jonathan Ullman](https://www.ccs.neu.edu/home/jullman/)
-* [Zhiwei Steven Wu](https://zstevenwu.com/)
-
 ## Contact
 
 [admin@differentialprivacy.org](mailto:admin@differentialprivacy.org)
+
+
+## Contributors
+{% for author in site.data.contributors %}
+* [{{ author[1].name }}]({{ author[1].homepage }})
+{% endfor %}
 
 ## Following
 


### PR DESCRIPTION
Improved management of contributors/authors & updated Welcome post

Contributors now listed in /_data/contributors.yml
Contributor list in /about.md is generated from this
Posts now include author lists and details are pulled from here